### PR TITLE
Adds 'scala' to the list of valid languages

### DIFF
--- a/lambda_code/yaml-schema.yml
+++ b/lambda_code/yaml-schema.yml
@@ -65,6 +65,7 @@ properties:
           - c
           - c++
           - javascript
+          - scala
       - type: array
         items:
           type: string
@@ -77,6 +78,7 @@ properties:
             - c
             - c++
             - javascript
+            - scala
 
   poc:
     type: array


### PR DESCRIPTION
Since we have a few projects that use Scala, particularly for Spark processing, we need to have 'scala' as an entry for the 'languages' section of the yaml-schema.yml file.