### PR TITLE
Standardize for ALL repos, not just services

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ All Digitalglobe code repos must contain a small metadata file, maintained by th
 
 Contents of this repo:
 
-* Some examples of the required metadata yaml file
+* Some examples of the required metadata yaml files
 * [A yaml schema that can be used for validation](./lambda_code/yaml-schema.yml)
 * Some code for a small service that grabs metadata from code repos, validates it, and returns status right into github
 * [Instructions for how to hook this service into your code repos](./docs/setup.md)
 
 
-## Service information file
+## Service information files
 Name: ```<service-name>.info.yml``` <br>
 Required: ```true```<br>
 Contents:  Contains metadata about the service or component including points of contact, data classification, URLs, documentation, etc.<br>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contents of this repo:
 * [Instructions for how to hook this service into your code repos](./docs/setup.md)
 
 
-## Service information files
+## Service information file.
 Name: ```<service-name>.info.yml``` <br>
 Required: ```true```<br>
 Contents:  Contains metadata about the service or component including points of contact, data classification, URLs, documentation, etc.<br>

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ All Digitalglobe code repos must contain a small metadata file, maintained by th
 
 Contents of this repo:
 
-* Some examples of the required metadata yaml file(s)
+* Some examples of the required metadata yaml file
 * [A yaml schema that can be used for validation](./lambda_code/yaml-schema.yml)
 * Some code for a small service that grabs metadata from code repos, validates it, and returns status right into github
 * [Instructions for how to hook this service into your code repos](./docs/setup.md)
 
 
-## Repository information file
-Name: ```<repo-name>.info.yml``` <br>
+## Service information file
+Name: ```<service-name>.info.yml``` <br>
 Required: ```true```<br>
-Contents:  Contains metadata about the repository including points of contact, data classification, URLs, documentation, etc.<br>
+Contents:  Contains metadata about the service or component including points of contact, data classification, URLs, documentation, etc.<br>
 
 ## Service API Specification
 Name: ```<service-name>.swagger.yml``` <br>

--- a/README.md
+++ b/README.md
@@ -4,26 +4,31 @@ All Digitalglobe code repos must contain a small metadata file, maintained by th
 
 Contents of this repo:
 
-* Some examples of the required metadata yaml files
+* Some examples of the required metadata yaml file(s)
 * [A yaml schema that can be used for validation](./lambda_code/yaml-schema.yml)
 * Some code for a small service that grabs metadata from code repos, validates it, and returns status right into github
 * [Instructions for how to hook this service into your code repos](./docs/setup.md)
 
 
-## Service information file.
-Name: ```<service-name>.info.yml``` <br>
+## Repository information file
+Name: ```<repo-name>.info.yml``` <br>
 Required: ```true```<br>
-Contents:  Contains metadata about the service or component including points of contact, URLs, documentation, etc.<br>
+Contents:  Contains metadata about the repository including points of contact, data classification, URLs, documentation, etc.<br>
 
 ## Service API Specification
 Name: ```<service-name>.swagger.yml``` <br>
 Required: ```required for RESTful services```<br>
 Contents:  A Swagger 2.0 API specification for the service<br>
 
+## Pipeline Controls
+Name: ```pipeline-controls.yml```<br>
+Required: ```required for items deployed via the common pipeline.```<br>
+Contents: [Complete documentation available in the Wiki](https://confluence-prod.us-gov-west-1.dg-govcloud-shared-services-01.satcloud.us/display/ISDECS/How+To+Use+Pipeline+Controls+in+the+Pipeline)
+
 ## CI/CD Deployment information
 Name: ```<service-name>.deployment-variables.yml```<br>
 Required: ```required for items deployed via the common pipeline.```<br>
-Contents: This will contain processing instructions for the CI/CD pipeline. <br> 
+Contents: This will contain processing instructions for the CI/CD pipeline. <br>
 Items such as the following will be specificed in this file
 * OAuth2 Scopes required by the service at runtime
 * Should the service be deployed to prod (we have some test-helpers and such that dont get deployed to prod.)

--- a/lambda_code/grab.py
+++ b/lambda_code/grab.py
@@ -57,7 +57,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                           commit,
                           'pending',
                           backlink_url,
-                          'Checking for valid <service-name>.info.yml file...',
+                          'Checking for valid <repo-name>.info.yml file...',
                           'DG Best Practice')
 
     urls = find_yaml_files(contents_url, commit)
@@ -68,7 +68,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                           commit,
                           'failure',
                           backlink_url,
-                          '<service-name>.info.yml file not found.',
+                          '<repo-name>.info.yml file not found.',
                           'DG Best Practice')
         return
 
@@ -82,7 +82,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                       commit,
                       'success',
                       backlink_url,
-                      'Valid <service-name>.info.yml found & validated.  Please remember to keep it up to date!',
+                      'Valid <repo-name>.info.yml found & validated.  Please remember to keep it up to date!',
                       'DG Best Practice')
         except:
             #record_invalid_yaml_file()
@@ -90,7 +90,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                               commit,
                               'failure',
                               backlink_url,
-                              '<service-name>.info.yml file is invalid.  Please adhere to spec: %s' % backlink_url,
+                              '<repo-name>.info.yml file is invalid.  Please adhere to spec: %s' % backlink_url,
                               'DG Best Practice')
 
 

--- a/lambda_code/grab.py
+++ b/lambda_code/grab.py
@@ -57,7 +57,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                           commit,
                           'pending',
                           backlink_url,
-                          'Checking for valid <repo-name>.info.yml file...',
+                          'Checking for valid <service-name>.info.yml file...',
                           'DG Best Practice')
 
     urls = find_yaml_files(contents_url, commit)
@@ -68,7 +68,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                           commit,
                           'failure',
                           backlink_url,
-                          '<repo-name>.info.yml file not found.',
+                          '<service-name>.info.yml file not found.',
                           'DG Best Practice')
         return
 
@@ -82,7 +82,7 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                       commit,
                       'success',
                       backlink_url,
-                      'Valid <repo-name>.info.yml found & validated.  Please remember to keep it up to date!',
+                      'Valid <service-name>.info.yml found & validated.  Please remember to keep it up to date!',
                       'DG Best Practice')
         except:
             #record_invalid_yaml_file()
@@ -90,9 +90,5 @@ def process_repo_commit(contents_url, repo_full_name, commit):
                               commit,
                               'failure',
                               backlink_url,
-                              '<repo-name>.info.yml file is invalid.  Please adhere to spec: %s' % backlink_url,
+                              '<service-name>.info.yml file is invalid.  Please adhere to spec: %s' % backlink_url,
                               'DG Best Practice')
-
-
-
-    

--- a/pet-store.info.yml
+++ b/pet-store.info.yml
@@ -1,10 +1,16 @@
 name: pet-store
-description: This service does simple things
+description: This repository contains simple things
 source: https://gitub.example.com/myorg/pet-store
 team: Pet Store Team
 language:
   - python
   - java
+data_classification:
+  - public
+  - company_proprietary
+  - sensitive
+  - program_proprietary
+  - regulated
 
 poc:
   - pagerduty: https://somepagerduty.com/url
@@ -19,14 +25,14 @@ documentation:
   - type: internal
     url: https://internal.example.com/docs/development/dev/pet-store
     wiki: https://github.example.com/myorg/pet-store/wiki
-    
+
 status:
   - type: status
     url: http://status.geobigdata.io/
   - type: uptime
     url: http://path/to/uptime/report
 
-dependencies: 
+dependencies:
   - name: complex-service
     source: https://github.com/somecompany/complex-service
   - name: super-service

--- a/pet-store.info.yml
+++ b/pet-store.info.yml
@@ -1,5 +1,5 @@
 name: pet-store
-description: This repository contains simple things
+description: This service does simple things
 source: https://gitub.example.com/myorg/pet-store
 team: Pet Store Team
 language:


### PR DESCRIPTION
- Trying to standardize docs and files for ALL kinds of repos, not just service repos.
- Add a section on <repo>.info.yml for Data Classification.

PS: I tried to add Phil Holtzman as a reviewer as well, but for some reason, I couldn't.